### PR TITLE
Schema 1.1.0 - Pending requests

### DIFF
--- a/schema/OIARequest.d.ts
+++ b/schema/OIARequest.d.ts
@@ -3,6 +3,7 @@ import { OIAWithholdings } from './OIAWithholdings.js';
 export type OIARequest = {
 	requester?: string,
 	id?: string,
+	requestUrl?: string,
 	responseUrl?: string,
 	withholdings: OIAWithholdings,
 };

--- a/schema/Policy.ts
+++ b/schema/Policy.ts
@@ -1,6 +1,7 @@
 import type { Version as PolicyVersion } from './PolicyVersion.js';
 import type { Notice } from './Notice.js';
 import type { Provenance } from './Provenance.js';
+import type { OIARequest } from './OIARequest.js';
 
 export enum PolicyType {
 	GENERAL_INSTRUCTIONS = 'General Instructions',
@@ -21,4 +22,5 @@ export type Policy = {
 	provenance?: Provenance[],
 	versions: PolicyVersion[],
 	notices?: Notice[],
+	pendingRequest?: OIARequest,
 };

--- a/schema/oia-request.schema.json
+++ b/schema/oia-request.schema.json
@@ -11,6 +11,11 @@
 			"description": "The releasing agency's internal reference ID for this request",
 			"type": "string"
 		},
+		"requestUrl": {
+			"description": "The URL of this OIA request",
+			"type": "string",
+			"format": "uri"
+		},
 		"responseUrl": {
 			"description": "The URL of the response to this OIA request",
 			"type": "string",

--- a/schema/policy.schema.json
+++ b/schema/policy.schema.json
@@ -1,5 +1,5 @@
 {
-	"$comment": "Current version: 1.0.0",
+	"$comment": "Current version: 1.1.0",
 	"title": "Policy",
 	"description": "A policy document",
 	"type": "object",
@@ -60,6 +60,10 @@
 			"items": {
 				"$ref": "notice.schema.json"
 			}
+		},
+		"pendingRequest": {
+			"description": "A pending OIA request regarding this document, if there is one",
+			"$ref": "oia-request.schema.json"
 		}
 	},
 	"required": [

--- a/src/templates/metadata-template.json
+++ b/src/templates/metadata-template.json
@@ -1,5 +1,5 @@
 {
-	"schemaVersion": "1.0.0",
+	"schemaVersion": "1.1.0",
 	"name": "string",
 	"previousNames": [
 		"string"
@@ -26,6 +26,7 @@
 					"oiaRequest": {
 						"requester": "string",
 						"id": "string",
+						"requestUrl": "url",
 						"responseUrl": "url",
 						"withholdings": "Undetermined"
 					},

--- a/src/templates/metadata-template.json
+++ b/src/templates/metadata-template.json
@@ -154,5 +154,13 @@
 			"title": "[string]",
 			"message": "string"
 		}
-	]
+	],
+	"pendingRequest": {
+		"oiaRequest": {
+			"requester": "string",
+			"id": "string",
+			"requestUrl": "url",
+			"withholdings": "Undetermined"
+		}
+	}
 }

--- a/src/templates/pages/content-report.ejs
+++ b/src/templates/pages/content-report.ejs
@@ -18,6 +18,8 @@
 	}
 
 	const sections = {
+		'Has pending request': (policy) => !!policy.pendingRequest,
+
 		'Needs OCR': (policy) => {
 			for (const version of policy.versions) {
 				for (const file of version.files) {

--- a/src/templates/pages/policy.ejs
+++ b/src/templates/pages/policy.ejs
@@ -17,7 +17,6 @@
 	const {
 		name,
 		type,
-		notices,
 		versions,
 	} = policy;
 
@@ -36,6 +35,15 @@
 		}
 
 		return false;
+	}
+
+	const notices = policy.notices?.concat() ?? [];
+
+	if (policy.pendingRequest?.requestUrl) {
+		notices.push({
+			type: 'info',
+			message: `There is <a href="${policy.pendingRequest.requestUrl}" target="_blank">a pending OIA request</a> regarding this document.`,
+		});
 	}
 %>
 

--- a/src/test-policies/test/metadata.json
+++ b/src/test-policies/test/metadata.json
@@ -353,5 +353,12 @@
 	"name": "Test Policy",
 	"previousNames": [
 		"Previous Test Policy"
-	]
+	],
+	"pendingRequest": {
+		"requester": "Requester Name",
+		"id": "Request ID",
+		"requestUrl": "https://policepolicy.nz#request",
+		"responseUrl": "https://policepolicy.nz#response",
+		"withholdings": "Undetermined"
+	}
 }


### PR DESCRIPTION
Since going live, we've found ourselves wanting to add notes about pending OIA requests for more information about a policy document.

This update to the schema adds a new optional `pendingRequest` property on the `Policy` type. It also updates the `OIARequest` type to have an optional `requestUrl` property that we can use to link to a pending request.

The migration for this version bumps version numbers and also attempts to construct a `requestUrl` for existing `OIARequest` objects found within `Provenance` arrays for policies, versions, and files, if the request is hosted on FYI. I've tested it locally on the `dev` data, but we'll follow [the usual migration strategy](https://github.com/HonestUniverse/nz-police-policy-directory#schema-migrations) once this branch is merged.

The new `pendingRequest` property is used to construct and info notice on the policy's page, and the content report page includes a section for policies with pending requests so we can review them and check if the request has had a response.