### PR TITLE
Change `bp-to` mixin to have a 0.01px gap, instead of 1px

### DIFF
--- a/src/assets/css/theme/_breakpoints.scss
+++ b/src/assets/css/theme/_breakpoints.scss
@@ -29,9 +29,9 @@ $breakpoints: (
 /// Use a media query for widths < the specified size. Expects value in `px` or as a string label e.g. `"m"`
 /// @param {string | length} $to - A size label or size to use for the media query
 @mixin bp-to($to) {
-	$toVal: map.get($breakpoints, $to) - 1px;
+	$toVal: map.get($breakpoints, $to) - 0.01px;
 	@if (not $toVal) {
-		$toVal: $to - 1px;
+		$toVal: $to - 0.01px;
 	}
 
 	@media (max-width: $toVal) {


### PR DESCRIPTION
The `bp-to` created an `@media` query for a `max-width` of `1px` beneath the specified threshold. However, browser viewport widths can be between integer pixel values, meaning they may hit a specific sub-pixel width that a pair of `bp-to` and `bp-from` mixins were meant to cover, but which is not covered (e.g. between `767px` and `768px`)

This PR updates that gap from `1px` to `0.01px`, so browsers should no longer be able to have viewports within the specific range of widths that is not covered (e.g. between `767.99px` and `768px`)