### PR TITLE
Schema v1.2.0 - Refused requests

### DIFF
--- a/build/migrate.ts
+++ b/build/migrate.ts
@@ -482,6 +482,17 @@ const migrations: Record<string, Migration> = {
 			}
 		}
 	},
+
+	/**
+	 * Changes in v1.2.0
+	 *
+	 * Added `Provenance['refused']?: DatePartial`
+	 *
+	 * This migration just increments the schema version number.
+	 */
+	['1.2.0']: function (policy: Policy): void {
+		policy.schemaVersion = '1.2.0';
+	},
 };
 
 migrateAll();

--- a/schema/Provenance.ts
+++ b/schema/Provenance.ts
@@ -21,6 +21,7 @@ export type Provenance = {
 	extracted?: DatePartial,
 	released?: DatePartial,
 	retrieved?: DatePartial,
+	refused?: DatePartial,
 	url?: string,
 	archiveUrl?: string,
 	fileUrl?: string,

--- a/schema/provenance.schema.json
+++ b/schema/provenance.schema.json
@@ -43,6 +43,10 @@
 			"description": "If the information was retrieved or released after its initial publication, the date on which it was retrieved",
 			"$ref": "date-partial.schema.json"
 		},
+		"refused": {
+			"description": "The date on which the release of the information was refused",
+			"$ref": "date-partial.schema.json"
+		},
 		"url": {
 			"description": "The URL of the page where the information was retrieved from",
 			"type": "string",
@@ -70,11 +74,17 @@
 	],
 	"allOf": [
 		{
-			"anyOf": [
-				{ "required": ["published"] },
-				{ "required": ["extracted"] },
-				{ "required": ["released"] },
-				{ "required": ["retrieved"] }
+			"$comment": "The \"refused\" property must only be used if none of the others are relevant",
+			"oneOf": [
+				{
+					"anyOf": [
+						{ "required": ["published"] },
+						{ "required": ["extracted"] },
+						{ "required": ["released"] },
+						{ "required": ["retrieved"] }
+					]
+				},
+				{ "required": ["refused"] }
 			]
 		},
 		{

--- a/src/templates/components/policy-summary.ejs
+++ b/src/templates/components/policy-summary.ejs
@@ -109,15 +109,15 @@
 				const provenance = mainFile?.provenance || latestVersion?.provenance || policy.provenance;
 
 				function getLatestDate(dateType, provenance) {
-					const dates = provenance.filter(
+					const dates = provenance?.filter(
 						(prov) => prov[dateType]
-					).map(
+					)?.map(
 						(prov) => new Date(prov[dateType])
-					).sort(
+					)?.sort(
 						(a, b) => b - a
 					)
 
-					return dates[0];
+					return dates?.[0];
 				}
 
 				const publishedDate = getLatestDate('published', provenance);

--- a/src/templates/components/provenance.ejs
+++ b/src/templates/components/provenance.ejs
@@ -8,6 +8,20 @@
 	}
 %>
 
+<%
+	const method = (() => {
+		if (provenance.refused) {
+			if (provenance.method === 'Released under the OIA') {
+				return 'Requested under the OIA';
+			} else {
+				return provenance.method;
+			}
+		} else {
+			return provenance.method;
+		}
+	})();
+%>
+
 <div class="provenance">
 	<%
 		const withholdings = provenance.withholdings || provenance.oiaRequest?.withholdings;
@@ -21,20 +35,23 @@
 				return ['Released', provenance.released];
 			} else if (provenance.retrieved) {
 				return ['Retrieved', provenance.retrieved];
+			} else if (provenance.refused) {
+				return ['Refused', provenance.refused];
 			}
 		})();
 	%>
 
-	<% if (provenance.method) { %>
+	<% if (method) { %>
 		<div class="provenance__source">
 			<% if (provenance.url) { %>
 				<a
 					<%- include('../helpers/href-with-target', { href: provenance.url }); %>
 					class="provenance__source__link"
-				><%= provenance.method %></a>
+				><%= method %></a>
 			<% } else { %>
-				<%= provenance.method %>
+				<%= method %>
 			<% } %>
+
 			<% if (provenance.source) { %>
 				by <%= provenance.source %>
 			<% } %>
@@ -49,7 +66,12 @@
 		<% if (withholdings) { %>
 			<% if (!(locals.options?.omitEmptyWithholdings && withholdings === 'None')) { %>
 				<div class="provenance__withholdings">
-					<%- include('../components/withholdings', { withholdings }) %>
+					<%- include('../components/withholdings', {
+						withholdings,
+						options: {
+							expandWithholdings: !!provenance.refused,
+						},
+					}) %>
 				</div>
 			<% } %>
 		<% } %>
@@ -66,7 +88,12 @@
 
 		<% if (withholdings) { %>
 			<div class="provenance__withholdings">
-				<%- include('../components/withholdings', { withholdings }) %>
+				<%- include('../components/withholdings', {
+					withholdings,
+					options: {
+						expandWithholdings: !!provenance.refused,
+					},
+				}) %>
 			</div>
 		<% } %>
 	<% } %>

--- a/src/templates/components/withholdings.ejs
+++ b/src/templates/components/withholdings.ejs
@@ -1,6 +1,9 @@
 <%##
 	locals: {
 		withholdings: OIAWithholdings,
+		options?: {
+			expandWithholdings?: boolean,
+		},
 	}
 %>
 
@@ -61,12 +64,14 @@
 		</div>
 	<% } else { %>
 		<%# Information was withheld %>
-		<details class="provenance__withholdings provenance__withholdings--fail">
-			<summary class="provenance__withholdings__summary">
+		<<%- locals.options?.expandWithholdings ? 'div' : 'details' %> class="provenance__withholdings provenance__withholdings--fail">
+			<<%- locals.options?.expandWithholdings ? 'div' : 'summary' %> class="provenance__withholdings__summary">
 				<span class="provenance__withholdings__summary-icon" aria-hidden="true"></span>
 				<span class="provenance__withholdings__summary-text">Information was withheld</span>
-				<span class="provenance__withholdings__summary-expand-icon" aria-hidden="true"></span>
-			</summary>
+				<% if (!locals.options?.expandWithholdings) { %>
+					<span class="provenance__withholdings__summary-expand-icon" aria-hidden="true"></span>
+				<% } %>
+			</<%- locals.options?.expandWithholdings ? 'div' : 'summary' %>>
 			<div class="provenance__withholdings__details">
 				<dl class="provenance__withholdings__list">
 					<% Object.entries(withholdings).forEach(([key, val]) => { %>
@@ -83,6 +88,6 @@
 					<% }) %>
 				</dl>
 			</div>
-		</details>
+		</<%- locals.options?.expandWithholdings ? 'div' : 'details' %>>
 	<% } %>
 <% } %>

--- a/src/templates/metadata-template.json
+++ b/src/templates/metadata-template.json
@@ -1,5 +1,5 @@
 {
-	"schemaVersion": "1.1.0",
+	"schemaVersion": "1.2.0",
 	"name": "string",
 	"previousNames": [
 		"string"
@@ -35,6 +35,7 @@
 					"extracted": "date",
 					"released": "date",
 					"retrieved": "date",
+					"refused": "date",
 					"url": "url",
 					"archiveUrl": "url",
 					"fileUrl": "url",

--- a/src/test-policies/refused/metadata.json
+++ b/src/test-policies/refused/metadata.json
@@ -1,0 +1,22 @@
+{
+	"type": "General Instructions",
+	"obsolete": true,
+	"schemaVersion": "1.1.0",
+	"name": "Refused Policy",
+	"provenance": [
+		{
+			"source": "NZ Police",
+			"method": "Released under the OIA",
+			"oiaRequest": {
+				"requester": "Test Requester",
+				"requestUrl": "https://policepolicy.nz#request",
+				"responseUrl": "https://policepolicy.nz#response",
+				"withholdings": {
+					"6(c)": "The document was withheld in full"
+				}
+			},
+			"refused": "2022-09-15"
+		}
+	],
+	"versions": []
+}


### PR DESCRIPTION
This PR updates the schema to v1.2.0, adding a new `refused?: DatePartial` property to the `Provenance` type.

It also includes a few UI updates to allow a "refused" variant of the provenance card to be displayed.

This allows us to describe policies that have been requested under the OIA, but which were refused.