### PR TITLE
Twitter card image

### DIFF
--- a/build/util/get-site-data.ts
+++ b/build/util/get-site-data.ts
@@ -11,6 +11,7 @@ export type SiteData = {
 	paths: {
 		policies: string,
 	},
+	domain: string,
 	navigation: {
 		header: NavigationItem[],
 		footer?: NavigationItem[],
@@ -43,6 +44,7 @@ export function getSiteData(): SiteData {
 		paths: {
 			policies: prepareNavPath(paths.policiesDst),
 		},
+		domain: 'policepolicy.nz',
 		navigation: {
 			header: [
 				{

--- a/src/templates/layout/head.ejs
+++ b/src/templates/layout/head.ejs
@@ -58,6 +58,8 @@
 		-->
 		<meta property="og:image" content="/assets/images/thomas-martinsen-4H9IuFBIpYM-unsplash.jpg" />
 		<meta property="og:image:alt" content="A grey notebook with a pen resting on top of it." />
+		<meta name="twitter:image" content="/assets/images/thomas-martinsen-4H9IuFBIpYM-unsplash.jpg" />
+		<meta name="twitter:image:alt" content="A grey notebook with a pen resting on top of it." />
 		<meta property="og:image:width" content="1920" />
 		<meta property="og:image:height" content="1135" />
 

--- a/src/templates/layout/head.ejs
+++ b/src/templates/layout/head.ejs
@@ -1,5 +1,7 @@
 <%##
 	locals: {
+		siteData: SiteData,
+
 		title: string,
 		description?: string,
 
@@ -56,9 +58,9 @@
 			Photo by Thomas Martinsen: https://unsplash.com/@faceline
 			Source: https://unsplash.com/photos/4H9IuFBIpYM
 		-->
-		<meta property="og:image" content="/assets/images/thomas-martinsen-4H9IuFBIpYM-unsplash.jpg" />
+		<meta property="og:image" content="https://<%- locals.siteData.domain %>/assets/images/thomas-martinsen-4H9IuFBIpYM-unsplash.jpg" />
 		<meta property="og:image:alt" content="A grey notebook with a pen resting on top of it." />
-		<meta name="twitter:image" content="/assets/images/thomas-martinsen-4H9IuFBIpYM-unsplash.jpg" />
+		<meta name="twitter:image" content="https://<%- locals.siteData.domain %>/assets/images/thomas-martinsen-4H9IuFBIpYM-unsplash.jpg" />
 		<meta name="twitter:image:alt" content="A grey notebook with a pen resting on top of it." />
 		<meta property="og:image:width" content="1920" />
 		<meta property="og:image:height" content="1135" />


### PR DESCRIPTION
The Twitter card has been broken because we provide an `og:image` meta tag but not a `twitter:image` meta tag. This PR adds `twitter:image` and `twitter:image:alt` meta tags.

I've tested this using the `staging` branch and it seems to have fixed the image in the Twitter card.