### PR TITLE
Id redirects

### DIFF
--- a/build/migrate.ts
+++ b/build/migrate.ts
@@ -495,6 +495,17 @@ const migrations: Record<string, Migration> = {
 	['1.2.0']: function (policy: Policy): void {
 		policy.schemaVersion = '1.2.0';
 	},
+
+	/**
+	 * Changes in v1.3.0
+	 *
+	 * Added `Version['previousIds']?: string[]`
+	 *
+	 * This migration just increments the schema version number.
+	 */
+	['1.3.0']: function (policy: Policy): void {
+		policy.schemaVersion = '1.3.0';
+	},
 };
 
 migrateAll();

--- a/schema/PolicyVersion.d.ts
+++ b/schema/PolicyVersion.d.ts
@@ -7,6 +7,7 @@ export type Version = {
 	isFirst?: boolean,
 	name?: string,
 	id: string,
+	previousIds?: string[],
 	duration: PolicyVersionDuration,
 	provenance: Provenance[],
 	files: File[],

--- a/schema/policy-version.schema.json
+++ b/schema/policy-version.schema.json
@@ -15,6 +15,13 @@
 			"description": "A generated ID string used to construct a unique URL for versions without a name",
 			"type": "string"
 		},
+		"previousIds": {
+			"description": "A list of generated ID strings that that should redirect to this version, e.g. if two versions were merged",
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
 		"duration": {
 			"description": "When this version of the policy was in effect",
 			"$ref": "policy-version-duration.schema.json"

--- a/schema/policy.schema.json
+++ b/schema/policy.schema.json
@@ -1,5 +1,5 @@
 {
-	"$comment": "Current version: 1.1.0",
+	"$comment": "Current version: 1.3.0",
 	"title": "Policy",
 	"description": "A policy document",
 	"type": "object",

--- a/src/templates/metadata-template.json
+++ b/src/templates/metadata-template.json
@@ -1,5 +1,5 @@
 {
-	"schemaVersion": "1.2.0",
+	"schemaVersion": "1.3.0",
 	"name": "string",
 	"previousNames": [
 		"string"

--- a/src/test-policies/test/metadata.json
+++ b/src/test-policies/test/metadata.json
@@ -221,7 +221,10 @@
 					"message": "This is a test notice on a version"
 				}
 			],
-			"id": "u-jdjqk"
+			"id": "u-jdjqk",
+			"previousIds": [
+				"u-aaaaa"
+			]
 		},
 		{
 			"name": "3.0",


### PR DESCRIPTION
Updated schema to v1.3.0 and added `PolicyVersion['previousIds']: string[]` and the scaffolding to automatically create redirects based on previous IDs.

This will support the work we need to do in combining two versions of the "Trespass" Police Manual chapter.