### PR TITLE
Combined two most recent "Trespass" versions into one

### DIFF
--- a/src/policies/trespass/metadata.json
+++ b/src/policies/trespass/metadata.json
@@ -6,65 +6,13 @@
 		{
 			"duration": {
 				"on": [
+					"2022-06-13",
 					"2022-08-29",
 					{
 						"year": 2022,
 						"month": 9
 					}
 				]
-			},
-			"provenance": [
-				{
-					"source": "NZ Police",
-					"method": "Proactively released",
-					"withholdings": "None",
-					"published": {
-						"year": 2022,
-						"month": 9
-					},
-					"extracted": "2022-08-29",
-					"retrieved": "2022-09-21",
-					"url": "https://www.police.govt.nz/about-us/publication/trespass-police-manual-chapter",
-					"archiveUrl": "https://web.archive.org/web/20220920215653/https://www.police.govt.nz/about-us/publication/trespass-police-manual-chapter",
-					"fileUrl": "https://www.police.govt.nz/sites/default/files/publications/trespass-290822.pdf",
-					"archiveFileUrl": "https://web.archive.org/web/20220920215701/https://www.police.govt.nz/sites/default/files/publications/trespass-290822.pdf"
-				}
-			],
-			"files": [
-				{
-					"path": "2022-08-29/trespass-290822.pdf",
-					"type": "application/pdf",
-					"documentType": "Policy",
-					"startingPage": 1,
-					"size": 1079152,
-					"licence": {
-						"name": "None"
-					},
-					"original": true,
-					"accessibility": {
-						"rating": "Undetermined",
-						"features": {
-							"text-based": {
-								"value": true
-							},
-							"semantics": {
-								"value": "Undetermined"
-							},
-							"unwatermarked": {
-								"value": true
-							}
-						}
-					}
-				}
-			],
-			"id": "u-xbggq"
-		},
-		{
-			"duration": {
-				"on": [
-					"2022-06-13"
-				],
-				"ended": true
 			},
 			"provenance": [
 				{
@@ -90,6 +38,48 @@
 				}
 			],
 			"files": [
+				{
+					"path": "2022-08-29/trespass-290822.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 1,
+					"size": 1079152,
+					"provenance": [
+						{
+							"source": "NZ Police",
+							"method": "Proactively released",
+							"withholdings": "None",
+							"published": {
+								"year": 2022,
+								"month": 9
+							},
+							"extracted": "2022-08-29",
+							"retrieved": "2022-09-21",
+							"url": "https://www.police.govt.nz/about-us/publication/trespass-police-manual-chapter",
+							"archiveUrl": "https://web.archive.org/web/20220920215653/https://www.police.govt.nz/about-us/publication/trespass-police-manual-chapter",
+							"fileUrl": "https://www.police.govt.nz/sites/default/files/publications/trespass-290822.pdf",
+							"archiveFileUrl": "https://web.archive.org/web/20220920215701/https://www.police.govt.nz/sites/default/files/publications/trespass-290822.pdf"
+						}
+					],
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Undetermined",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": "Undetermined"
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
 				{
 					"path": "2022-06-13/parliament-protest-oia-releases-policing-response-21jul2022.pdf",
 					"type": "application/pdf",
@@ -166,7 +156,10 @@
 					}
 				}
 			],
-			"id": "u-xqatk"
+			"id": "u-xqatk",
+			"previousIds": [
+				"u-xbggq"
+			]
 		},
 		{
 			"duration": {


### PR DESCRIPTION
A new document for the "Trespass" Police Manual chapter was added in PR#24, but it was incorrectly marked up as being a new version. This PR combines it with the prior version, since its content has not changed since then.