### PR TITLE
Ensure working ts-node for newer Node versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"stylelint-config-recommended-scss": "^6.0.0",
 				"template-ejs-loader": "^0.9.1",
 				"ts-loader": "^9.2.8",
-				"ts-node": "^10.7.0",
+				"ts-node": "^10.9.1",
 				"typescript": "^4.6.3",
 				"webpack": "^5.72.0",
 				"webpack-cli": "^4.9.2"
@@ -140,20 +140,13 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/@cspotcode/source-map-consumer": {
-			"version": "0.8.0",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">= 12"
-			}
-		},
 		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.7.0",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@cspotcode/source-map-consumer": "0.8.0"
+				"@jridgewell/trace-mapping": "0.3.9"
 			},
 			"engines": {
 				"node": ">=12"
@@ -225,6 +218,31 @@
 			"version": "1.2.1",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.4.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -4206,11 +4224,12 @@
 			}
 		},
 		"node_modules/ts-node": {
-			"version": "10.7.0",
+			"version": "10.9.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@cspotcode/source-map-support": "0.7.0",
+				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
 				"@tsconfig/node12": "^1.0.7",
 				"@tsconfig/node14": "^1.0.0",
@@ -4221,7 +4240,7 @@
 				"create-require": "^1.1.0",
 				"diff": "^4.0.1",
 				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.0",
+				"v8-compile-cache-lib": "^3.0.1",
 				"yn": "3.1.1"
 			},
 			"bin": {
@@ -4604,15 +4623,13 @@
 				}
 			}
 		},
-		"@cspotcode/source-map-consumer": {
-			"version": "0.8.0",
-			"dev": true
-		},
 		"@cspotcode/source-map-support": {
-			"version": "0.7.0",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
 			"dev": true,
 			"requires": {
-				"@cspotcode/source-map-consumer": "0.8.0"
+				"@jridgewell/trace-mapping": "0.3.9"
 			}
 		},
 		"@discoveryjs/json-ext": {
@@ -4666,6 +4683,28 @@
 		"@humanwhocodes/object-schema": {
 			"version": "1.2.1",
 			"dev": true
+		},
+		"@jridgewell/resolve-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.4.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
+		},
+		"@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -7141,10 +7180,12 @@
 			}
 		},
 		"ts-node": {
-			"version": "10.7.0",
+			"version": "10.9.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
 			"dev": true,
 			"requires": {
-				"@cspotcode/source-map-support": "0.7.0",
+				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
 				"@tsconfig/node12": "^1.0.7",
 				"@tsconfig/node14": "^1.0.0",
@@ -7155,7 +7196,7 @@
 				"create-require": "^1.1.0",
 				"diff": "^4.0.1",
 				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.0",
+				"v8-compile-cache-lib": "^3.0.1",
 				"yn": "3.1.1"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"stylelint-config-recommended-scss": "^6.0.0",
 		"template-ejs-loader": "^0.9.1",
 		"ts-loader": "^9.2.8",
-		"ts-node": "^10.7.0",
+		"ts-node": "^10.9.1",
 		"typescript": "^4.6.3",
 		"webpack": "^5.72.0",
 		"webpack-cli": "^4.9.2"


### PR DESCRIPTION
The current build process fails when using the ts-node/esm loader on certain Node versions (Node 16.17+ and Node 18.6.0+ seemingly). Updated to have a minimum version that's known to work (per https://github.com/TypeStrong/ts-node/issues/1839).