### PR TITLE
Use policy name when determining dist directory name

### DIFF
--- a/build/build.ts
+++ b/build/build.ts
@@ -37,18 +37,19 @@ export async function createBuildPlugins(policiesPath = paths.policies) {
 
 	const plugins: ReturnType<BuildStep> = [];
 
-	const policiesByName = await readAllPolicies(policiesPath);
+	const policiesByDirName = await readAllPolicies(policiesPath);
 	const policiesByNameSafe: Record<string, Policy> = {};
 
 	// Asset build steps
 	plugins.push(...await gatherBuildStepPlugins(assetBuildSteps, paths.assets, paths.distAssetsFull, null));
 
 	// Loop through policies and generate each policy's build steps
-	for (const [policyName, policy] of Object.entries(policiesByName)) {
+	for (const [policySrcDir, policy] of Object.entries(policiesByDirName)) {
+		const policyName = policy.name;
 		const policyNameSafe = toUrlSegment(policyName);
 		policiesByNameSafe[policyNameSafe] = policy;
 
-		const policySrcPath = `${policiesPath}/${policyName}`;
+		const policySrcPath = `${policiesPath}/${policySrcDir}`;
 		const policyDstPath = `${paths.policiesDst}/${policyNameSafe}`;
 
 		plugins.push(...await gatherBuildStepPlugins(policyBuildSteps, policySrcPath, policyDstPath, {
@@ -71,7 +72,7 @@ export async function createBuildPlugins(policiesPath = paths.policies) {
 
 	// Redirect build steps
 	plugins.push(...await gatherBuildStepPlugins(redirectBuildSteps, paths.src, paths.policiesDst, {
-		directory: policiesByName,
+		directory: policiesByNameSafe,
 	}));
 
 	return plugins;


### PR DESCRIPTION
We have been using src directory name, instead of policy name, when determining a policy's dst directory name and building redirects.

This has allowed for inconsistency between policy name and directory name in some cases, such as for some Drugs chapters where the name was too long to use it as a src directory name. It has also resulted in inconsistency when policy names have been updated in metadata but not in their src directory name.

In the particular case of the "Kidnap for ransom" policy, renaming the metadata only but not the directory from "Kidnapping for ransom" has resulted in an infinite redirect loop.

This PR changes how we determine dist directory names for policies to use the name of the policy itself, independent of src policy name. This aligns better with our original intent, and fixes the infinite redirect loop.

Currently, this PR doesn't include an legacy redirect generation step for any policies that might have their paths changed as a result of this change.