### PR TITLE
Search and surveillance

### DIFF
--- a/src/policies/search-part-01-search-introduction/metadata.json
+++ b/src/policies/search-part-01-search-introduction/metadata.json
@@ -1,55 +1,86 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Search Part 01 - Search introduction",
 	"versions": [
 		{
 			"id": "u-nvquf",
 			"duration": {
-				"start": "2020-11-10"
+				"on": [
+					"2021-06-08",
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"extracted": "2021-06-08",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 3,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/search-part-02-search-warrants/metadata.json
+++ b/src/policies/search-part-02-search-warrants/metadata.json
@@ -1,55 +1,88 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Search Part 02 - Search warrants ",
 	"versions": [
 		{
 			"id": "u-nwfpk",
 			"duration": {
-				"start": "2020-11-10"
+				"on": [
+					"2021-06-08",
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": {
+							"6(c)": "Information has been withheld on page 15."
+						}
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"extracted": "2021-06-08",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 19,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/search-part-03-warrantless-powers-to-search-places-vehicles-and-things/metadata.json
+++ b/src/policies/search-part-03-warrantless-powers-to-search-places-vehicles-and-things/metadata.json
@@ -6,7 +6,9 @@
 		{
 			"duration": {
 				"on": [
-					"2022-07-13"
+					"2021-06-08",
+					"2022-07-13",
+					"2022-10-07"
 				]
 			},
 			"provenance": [
@@ -27,6 +29,92 @@
 				}
 			],
 			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 50,
+					"size": 5136884,
+					"provenance": [
+						{
+							"source": "NZ Police",
+							"method": "Released under the OIA",
+							"oiaRequest": {
+								"requester": "John Walter",
+								"id": "IR-01-22-22523",
+								"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+								"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+								"withholdings": "None"
+							},
+							"extracted": "2021-06-08",
+							"released": "2022-10-07",
+							"retrieved": "2022-10-07",
+							"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+							"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
+						}
+					],
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"provenance": [
+						{
+							"source": "NZ Police",
+							"method": "Released under the OIA",
+							"oiaRequest": {
+								"requester": "John Walter",
+								"id": "IR-01-22-22523",
+								"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+								"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+								"withholdings": "None"
+							},
+							"extracted": "2021-06-08",
+							"released": "2022-10-07",
+							"retrieved": "2022-10-07",
+							"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+							"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
+						}
+					],
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
 				{
 					"path": "../../bulk-files/2022-07-13/SI IR 01 22 18456 Response.pdf",
 					"type": "application/pdf",
@@ -114,10 +202,5 @@
 			],
 			"id": "u-qeihx"
 		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/search-part-04-consent-searches/metadata.json
+++ b/src/policies/search-part-04-consent-searches/metadata.json
@@ -1,55 +1,86 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Search Part 04 - Consent searches",
 	"versions": [
 		{
 			"id": "u-ycpie",
 			"duration": {
-				"start": "2020-11-11"
+				"on": [
+					"2021-06-08",
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"extracted": "2021-06-08",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 72,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/search-part-05-carrying-out-search-powers-with-or-without-warrants/metadata.json
+++ b/src/policies/search-part-05-carrying-out-search-powers-with-or-without-warrants/metadata.json
@@ -4,11 +4,99 @@
 	"name": "Search Part 05 - Carrying out search powers with or without warrants",
 	"versions": [
 		{
+			"duration": {
+				"on": [
+					"2021-06-08",
+					"2022-10-07"
+				]
+			},
+			"provenance": [
+				{
+					"source": "NZ Police",
+					"method": "Released under the OIA",
+					"oiaRequest": {
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": {
+							"6(c)": "Information has been withheld on pages 11, 13, 14, 21, 27–29, and 31–33."
+						}
+					},
+					"extracted": "2021-06-08",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
+				}
+			],
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 77,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			],
+			"notices": [
+				{
+					"type": "info",
+					"message": "Most parts of this document that were withheld when this version was released in October 2022 were not withheld when it was released in 2020."
+				}
+			],
+			"id": "u-fwyvi"
+		},
+		{
 			"id": "u-yhkuu",
 			"duration": {
 				"on": [
 					"2020-06-17"
-				]
+				],
+				"ended": true
 			},
 			"provenance": [
 				{
@@ -79,10 +167,5 @@
 				}
 			]
 		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/search-part-06-roadblocks-and-stopping-vehicles-for-search-purposes/metadata.json
+++ b/src/policies/search-part-06-roadblocks-and-stopping-vehicles-for-search-purposes/metadata.json
@@ -1,55 +1,86 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Search Part 06  - Roadblocks and stopping vehicles for search purposes ",
 	"versions": [
 		{
 			"id": "u-xzakb",
 			"duration": {
-				"start": "2021-02-24"
+				"on": [
+					"2021-06-08",
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"extracted": "2021-06-08",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 118,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/search-part-07-methods-for-searching-places-and-vehicles/metadata.json
+++ b/src/policies/search-part-07-methods-for-searching-places-and-vehicles/metadata.json
@@ -1,55 +1,86 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Search Part 07 - Methods for searching places and vehicles",
 	"versions": [
 		{
 			"id": "u-qotao",
 			"duration": {
-				"start": "2021-02-11"
+				"on": [
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": {
+							"6(c)": "Information has been withheld on pages 8–19."
+						}
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 129,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/search-part-08-searching-people/metadata.json
+++ b/src/policies/search-part-08-searching-people/metadata.json
@@ -21,7 +21,6 @@
 							"6(c)": "Information has been withheld on page 21."
 						}
 					},
-					"extracted": "2021-06-08",
 					"released": "2022-10-07",
 					"retrieved": "2022-10-07",
 					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",

--- a/src/policies/search-part-08-searching-people/metadata.json
+++ b/src/policies/search-part-08-searching-people/metadata.json
@@ -4,27 +4,82 @@
 		{
 			"id": "u-shukp",
 			"duration": {
-				"start": "2022-01-28"
+				"on": [
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": {
+							"6(c)": "Information has been withheld on page 21."
+						}
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"extracted": "2021-06-08",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 148,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
 	],
 	"schemaVersion": "1.3.0",

--- a/src/policies/search-part-09-production-orders/metadata.json
+++ b/src/policies/search-part-09-production-orders/metadata.json
@@ -20,7 +20,6 @@
 						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
 						"withholdings": "None"
 					},
-					"extracted": "2021-06-08",
 					"released": "2022-10-07",
 					"retrieved": "2022-10-07",
 					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",

--- a/src/policies/search-part-09-production-orders/metadata.json
+++ b/src/policies/search-part-09-production-orders/metadata.json
@@ -4,11 +4,90 @@
 	"name": "Search Part 09 - Production orders",
 	"versions": [
 		{
+			"duration": {
+				"on": [
+					"2022-10-07"
+				]
+			},
+			"provenance": [
+				{
+					"source": "NZ Police",
+					"method": "Released under the OIA",
+					"oiaRequest": {
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
+					},
+					"extracted": "2021-06-08",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
+				}
+			],
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 182,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			],
+			"id": "u-tapkd"
+		},
+		{
 			"id": "u-wehqh",
 			"duration": {
 				"on": [
 					"2020-06-17"
-				]
+				],
+				"ended": true
 			},
 			"provenance": [
 				{
@@ -79,10 +158,5 @@
 				}
 			]
 		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/search-part-10-examination-orders/metadata.json
+++ b/src/policies/search-part-10-examination-orders/metadata.json
@@ -1,55 +1,84 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Search Part 10 - Examination orders",
 	"versions": [
 		{
 			"id": "u-ettcz",
 			"duration": {
-				"start": "2020-11-11"
+				"on": [
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 195,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/search-part-11-declaratory-orders/metadata.json
+++ b/src/policies/search-part-11-declaratory-orders/metadata.json
@@ -1,55 +1,84 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Search Part 11 - Declaratory orders",
 	"versions": [
 		{
 			"id": "u-wyjvx",
 			"duration": {
-				"start": "2020-11-12"
+				"on": [
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 207,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/search-part-12-procedures-applying-to-seized-and-produced-things/metadata.json
+++ b/src/policies/search-part-12-procedures-applying-to-seized-and-produced-things/metadata.json
@@ -1,55 +1,86 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Search Part 12 - Procedures applying to seized and produced things ",
 	"versions": [
 		{
 			"id": "u-oeeth",
 			"duration": {
-				"start": "2020-11-12"
+				"on": [
+					"2021-06-08",
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"extracted": "2021-06-08",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 215,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/search-part-13-privilege-and-immunities-under-the-act/metadata.json
+++ b/src/policies/search-part-13-privilege-and-immunities-under-the-act/metadata.json
@@ -1,55 +1,84 @@
 {
-	"name": "Search Part 13 - Privilege and immunities under the Act ",
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
+	"name": "Search Part 13 - Privilege and immunities under the Act",
 	"versions": [
 		{
 			"id": "u-vfdqo",
 			"duration": {
-				"start": "2020-11-12"
+				"on": [
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 232,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/search-part-14-reporting/metadata.json
+++ b/src/policies/search-part-14-reporting/metadata.json
@@ -1,55 +1,84 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Search Part 14 - Reporting",
 	"versions": [
 		{
 			"id": "u-poeip",
 			"duration": {
-				"start": "2020-11-11"
+				"on": [
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 250,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/search-part-15-government-agency-requests-for-assistance-with-search-warrants/metadata.json
+++ b/src/policies/search-part-15-government-agency-requests-for-assistance-with-search-warrants/metadata.json
@@ -1,13 +1,95 @@
 {
 	"schemaVersion": "1.3.0",
 	"type": "Police Manual chapter",
+	"name": "Search Part 15 - Government agency requests for assistance with search warrants",
+	"previousNames": [
+		"Search Part 15 - Government agency requests for assistance with search warrants and production orders"
+	],
 	"versions": [
+		{
+			"duration": {
+				"on": [
+					"2022-10-07"
+				]
+			},
+			"provenance": [
+				{
+					"source": "NZ Police",
+					"method": "Released under the OIA",
+					"oiaRequest": {
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
+					},
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
+				}
+			],
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 263,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			],
+			"id": "u-sweia"
+		},
 		{
 			"duration": {
 				"on": [
 					"2021-06-14",
 					"2021-06-28"
-				]
+				],
+				"ended": true
 			},
 			"provenance": [
 				{
@@ -50,21 +132,10 @@
 							}
 						}
 					},
-					"notices": [
-						{
-							"type": "info",
-							"title": "Bulk file",
-							"message": "This file contains multiple documents. \"Government agency requests for assistance with search warrants and production orders\" covers pages 1-27 of the file."
-						}
-					],
 					"documentType": "Policy"
 				}
 			],
 			"id": "u-kwoyj"
 		}
-	],
-	"name": "Search Part 15 - Government agency requests for assistance with search warrants",
-	"previousNames": [
-		"Search Part 15 - Government agency requests for assistance with search warrants and production orders"
 	]
 }

--- a/src/policies/search-part-16-property-damage-incurred-during-searches-or-exercise-of-statutory-powers/metadata.json
+++ b/src/policies/search-part-16-property-damage-incurred-during-searches-or-exercise-of-statutory-powers/metadata.json
@@ -1,55 +1,86 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Search Part 16 - Property damage incurred during searches or exercise of statutory powers",
 	"versions": [
 		{
 			"id": "u-wjjnx",
 			"duration": {
-				"start": "2021-01-26"
+				"on": [
+					"2021-06-08",
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"extracted": "2021-06-08",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 289,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/surveillance-categories-of-surveillance-with-a-device/metadata.json
+++ b/src/policies/surveillance-categories-of-surveillance-with-a-device/metadata.json
@@ -1,50 +1,88 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Surveillance - Categories of surveillance with a device",
 	"versions": [
 		{
 			"id": "u-pfeuq",
 			"duration": {
-				"start": "2018-08-22"
+				"on": [
+					"2021-07-12",
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": {
+							"6(c)": "Information has been withheld on page 15."
+						}
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"extracted": "2021-07-12",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
-		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 307,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
 	]
 }

--- a/src/policies/surveillance-introduction/metadata.json
+++ b/src/policies/surveillance-introduction/metadata.json
@@ -1,55 +1,86 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Surveillance - Introduction",
 	"versions": [
 		{
 			"id": "u-azdvi",
 			"duration": {
-				"start": "2018-08-22"
+				"on": [
+					"2021-07-12",
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"extracted": "2021-07-12",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 297,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/surveillance-privilege-and-immunities-involving-surveillance/metadata.json
+++ b/src/policies/surveillance-privilege-and-immunities-involving-surveillance/metadata.json
@@ -1,55 +1,86 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Surveillance - Privilege and immunities involving surveillance",
 	"versions": [
 		{
 			"id": "u-cnnfi",
 			"duration": {
-				"start": "2018-08-07"
+				"on": [
+					"2021-07-12",
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"extracted": "2021-07-12",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 395,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/surveillance-retention-destruction-of-surveillance-data-documents/metadata.json
+++ b/src/policies/surveillance-retention-destruction-of-surveillance-data-documents/metadata.json
@@ -1,55 +1,86 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Surveillance - Retention & destruction of surveillance data & documents",
 	"versions": [
 		{
 			"id": "u-pfdbg",
 			"duration": {
-				"start": "2018-08-06"
+				"on": [
+					"2021-07-12",
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"extracted": "2021-07-12",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 389,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/surveillance-surveillance-by-radar-and-from-aircraft-drones-etc/metadata.json
+++ b/src/policies/surveillance-surveillance-by-radar-and-from-aircraft-drones-etc/metadata.json
@@ -1,55 +1,86 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Surveillance - Surveillance by radar and from aircraft, drones etc",
 	"versions": [
 		{
 			"id": "u-tgjpu",
 			"duration": {
-				"start": "2018-08-22"
+				"on": [
+					"2021-07-12",
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"extracted": "2021-07-12",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 357,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/surveillance-surveillance-device-warrants/metadata.json
+++ b/src/policies/surveillance-surveillance-device-warrants/metadata.json
@@ -1,55 +1,86 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Surveillance - Surveillance device warrants",
 	"versions": [
 		{
 			"id": "u-ejgtc",
 			"duration": {
-				"start": "2018-10-02"
+				"on": [
+					"2021-07-12",
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": "None"
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"extracted": "2021-07-12",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 323,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/surveillance-surveillance-reporting/metadata.json
+++ b/src/policies/surveillance-surveillance-reporting/metadata.json
@@ -1,55 +1,88 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Surveillance - Surveillance reporting",
 	"versions": [
 		{
 			"id": "u-pjabu",
 			"duration": {
-				"start": "2018-09-12"
+				"on": [
+					"2021-07-12",
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": {
+							"6(c)": "Information was withheld from page 13."
+						}
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"extracted": "2021-07-12",
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 375,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/surveillance-surveillance-squad/metadata.json
+++ b/src/policies/surveillance-surveillance-squad/metadata.json
@@ -1,55 +1,86 @@
 {
+	"schemaVersion": "1.3.0",
+	"type": "Police Manual chapter",
 	"name": "Surveillance - Surveillance squad",
 	"versions": [
 		{
 			"id": "u-bkvfy",
 			"duration": {
-				"start": "2021-02-23"
+				"on": [
+					"2022-10-07"
+				]
 			},
 			"provenance": [
 				{
 					"source": "NZ Police",
 					"method": "Released under the OIA",
 					"oiaRequest": {
-						"requester": "Mark Hanna",
-						"id": "IR-01-22-11586",
-						"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-						"withholdings": "None",
-						"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
+						"requester": "John Walter",
+						"id": "IR-01-22-22523",
+						"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
+						"responseUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+						"withholdings": {
+							"6(c)": "Information was withheld from the table of contents and pages 5–7 and 9."
+						}
 					},
-					"extracted": "2022-05-22",
-					"released": "2022-06-13",
-					"retrieved": "2022-06-18",
-					"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-					"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
+					"released": "2022-10-07",
+					"retrieved": "2022-10-07",
+					"url": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022#incoming-78193",
+					"fileUrl": "https://fyi.org.nz/request/20078/response/78193/attach/4/Walter%20John%20IR%2001%2022%2022523%20Response.pdf"
 				}
 			],
-			"files": []
+			"files": [
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "Policy",
+					"startingPage": 366,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				},
+				{
+					"path": "../../bulk-files/2022-10-07/Walter John IR 01 22 22523 Response.pdf",
+					"type": "application/pdf",
+					"documentType": "OIA response letter",
+					"startingPage": 1,
+					"size": 5136884,
+					"licence": {
+						"name": "None"
+					},
+					"original": true,
+					"accessibility": {
+						"rating": "Poor",
+						"features": {
+							"text-based": {
+								"value": true
+							},
+							"semantics": {
+								"value": false
+							},
+							"unwatermarked": {
+								"value": true
+							}
+						}
+					}
+				}
+			]
 		}
-	],
-	"schemaVersion": "1.3.0",
-	"type": "Police Manual chapter",
-	"provenance": [
-		{
-			"source": "NZ Police",
-			"method": "Released under the OIA",
-			"oiaRequest": {
-				"requester": "Mark Hanna",
-				"id": "IR-01-22-11586",
-				"responseUrl": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-				"withholdings": "None",
-				"requestUrl": "https://fyi.org.nz/request/19200-police-policy-documents"
-			},
-			"extracted": "2022-05-22",
-			"released": "2022-06-13",
-			"retrieved": "2022-06-18",
-			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
-			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
-		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }


### PR DESCRIPTION
On 2022-10-07, NZ Police released all 16 Police Manual chapters under the "Search" section, and all eight chapters under the "Surveillance" section. This PR adds all 24 of these chapters to the directory.