### PR TITLE
Removed pending requests that have been completed

### DIFF
--- a/src/policies/criminal-disclosure/metadata.json
+++ b/src/policies/criminal-disclosure/metadata.json
@@ -156,10 +156,5 @@
 			],
 			"id": "u-jzzse"
 		}
-	],
-	"pendingRequest": {
-		"requester": "I Brown",
-		"requestUrl": "https://fyi.org.nz/request/20480-police-manual-chapters-on-criminal-procedure",
-		"withholdings": "Undetermined"
-	}
+	]
 }

--- a/src/policies/search-part-08-searching-people/metadata.json
+++ b/src/policies/search-part-08-searching-people/metadata.json
@@ -100,10 +100,5 @@
 			"url": "https://fyi.org.nz/request/19200-police-policy-documents#incoming-74199",
 			"fileUrl": "https://fyi.org.nz/request/19200/response/74199/attach/2/List%20of%20all%20Police%20Manual%20chapters%20as%20at%20May%202022%20searchable.xlsx"
 		}
-	],
-	"pendingRequest": {
-		"requester": "John Walter",
-		"requestUrl": "https://fyi.org.nz/request/20078-police-manuals-all-search-and-surveillance-chapters-2022",
-		"withholdings": "Undetermined"
-	}
+	]
 }


### PR DESCRIPTION
I just audited the pending requests from the content report. This PR removes two pending requests that have been completed.